### PR TITLE
a couple of small fixes to make mflux-streamlit work

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ mflux-streamlit
 # dev workaround: run the main.py
 uv venv && source .venv/bin/activate
 uv pip install -e .
-streamlit src/app.py
+streamlit run src/app.py
 ```
 
 ## License

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ),
     keywords='streamlit, mflux, mlx',
     install_requires=[
-        "mflux>=0.4.1,<1.0",
+        "mflux==0.4.1",
         "streamlit>=1.10.0,<2.0",
     ],
     zip_safe=False


### PR DESCRIPTION
• mflux 0.6.2 has a very different CLI API.. so pin this repo to mflux 0.4.1
• `streamlit run src/app.py`.. not `streamlit src/app.py`